### PR TITLE
Fix typo when using root repository value for BUILD_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The discussion is documented [here](https://github.com/maxheld83/ghaction-ghpage
 ## Environment Variables
 
 Just `BUILD_DIR`, the build directory relative to your repository root.
-You can also pass `/.` if you want to push your repository root.
+You can also pass `.` if you want to push your repository root.
 
 
 ## Arguments


### PR DESCRIPTION
There's a small typo in the README (cf. #5 ).

