### PR TITLE
Use HEAD instead of master as current

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
 git add . && \
 git commit -m 'Deploy to GitHub pages' && \
-git push --force $REMOTE_REPO master:$REMOTE_BRANCH && \
+git push --force $REMOTE_REPO HEAD:$REMOTE_BRANCH && \
 rm -fr .git && \
 cd $GITHUB_WORKSPACE && \
 echo "Content of $BUILD_DIR has been deployed to GitHub Pages."


### PR DESCRIPTION
Hi,

Got into a small issue when using this action within a repo with no `master` branch (or with a _default_ branch not called `master`), due to the [following line](https://github.com/maxheld83/ghpages/blob/0e82463e92c01b3df93a0a0312fdcaa17e8b62a6/entrypoint.sh#L25):

```
git push --force $REMOTE_REPO master:$REMOTE_BRANCH
```

By using `HEAD` instead of directly mention `master`, we can fix this.