### PR TITLE
Return neutral code when nothing to commit

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,10 @@ fi && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
+if [ -z "$(git status --porcelain)" ]; then
+    echo "Nothing to commit" && \
+    exit 78
+fi && \
 git add . && \
 git commit -m 'Deploy to GitHub pages' && \
 git push --force $REMOTE_REPO HEAD:$REMOTE_BRANCH && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ if [ -z "$(git status --porcelain)" ]; then
 fi && \
 git add . && \
 git commit -m 'Deploy to GitHub pages' && \
-git push --force $REMOTE_REPO HEAD:$REMOTE_BRANCH && \
+git push --force $REMOTE_REPO master:$REMOTE_BRANCH && \
 rm -fr .git && \
 cd $GITHUB_WORKSPACE && \
 echo "Content of $BUILD_DIR has been deployed to GitHub Pages."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
 if [ -z "$(git status --porcelain)" ]; then
     echo "Nothing to commit" && \
-    exit 78
+    exit 0
 fi && \
 git add . && \
 git commit -m 'Deploy to GitHub pages' && \


### PR DESCRIPTION
Here's an implementation for the issue addressed in issue #7 

The process return a `neutral` when there's nothing to commit, instead of an error.