### PR TITLE
Add note about required permissions on PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Deployment to GitHub pages happens by `git push`ing to the `gh-pages` (or `maste
 To authorise this, the GitHub action needs a secret.
 For now, somewhat confusingly, the `GITHUB_TOKEN` [available for every repo](https://developer.github.com/actions/creating-workflows/storing-secrets/) *does* suffice to push to `gh-pages`, but *does not* suffice to trigger a  page build on GitHub, or even propagate the content to the GitHub content-delivery network.
 
-You therefore **have to [create a custom Personal Access Token (PAT)](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)** much like you'd do for external services (say, Travis).
+You therefore **have to [create a custom Personal Access Token (PAT)](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)** much like you'd do for external services (say, Travis). This token must be created with `repo` permissions in order to deploy to Github Pages.
 You then have to paste this token into the GitHub UI as a secret under the name `GH_PAT` (repository settings/secrets) and call it in the action as in the below.
 
 I've asked GitHub to streamline this process.


### PR DESCRIPTION
I got a little hung up yesterday, when trying to use this Action, because it wasn't clear what permissions were required on the PAT that we need to generate to use this project. Making it explicit that you need `repo` permissions should help folks avoid some guesswork.