### PR TITLE
Option to explicitly set the committer

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,9 +17,10 @@ if [[ "$REPONAME" == "$GHIO" ]]; then
 else
   REMOTE_BRANCH="gh-pages"
 fi && \
+COMMIT_USER="${GH_USER_NAME:-$GITHUB_ACTOR}" && \
 git init && \
-git config user.name "${GITHUB_ACTOR}" && \
-git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
+git config user.name "$COMMIT_USER" && \
+git config user.email "${GH_USER_EMAIL:-$COMMIT_USER@users.noreply.github.com}" && \
 if [ -z "$(git status --porcelain)" ]; then
     echo "Nothing to commit" && \
     exit 0


### PR DESCRIPTION
It isn't always clear who is the person or app that initiated the workflow (ie. `GITHUB_ACTOR`) and it may be desirable to explicitly set who the committer is when the action is run.

This commit provides the option to set the committer using the `GH_USER_NAME` and/or `GH_USER_EMAIL` environment variables. If neither environment variable is set it will default to the original behaviour of just using `GITHUB_ACTOR`.

A use-case for this functionality can be found at upptime/upptime#118