### PR TITLE
Use branch main instead of master

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ REPONAME="$(echo $GITHUB_REPOSITORY| cut -d'/' -f 2)" && \
 OWNER="$(echo $GITHUB_REPOSITORY| cut -d'/' -f 1)" && \
 GHIO="${OWNER}.github.io" && \
 if [[ "$REPONAME" == "$GHIO" ]]; then
-  REMOTE_BRANCH="master"
+  REMOTE_BRANCH="main"
 else
   REMOTE_BRANCH="gh-pages"
 fi && \


### PR DESCRIPTION
Most convention using now main instead of master even github.
Now when we want create new repository the default name branch is main, so keep master branch name is not good, it will force change default name branch to master for publish doc / gh page