### PR TITLE
Fix for git version >=2.35.2: Add the current dir as a git safe dir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ if [[ "$REPONAME" == "$GHIO" ]]; then
 else
   REMOTE_BRANCH="gh-pages"
 fi && \
+git config --system --add safe.directory $PWD \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \


### PR DESCRIPTION
From git 2.35.2, the repository needs to be owned by the current user. See https://github.blog/2022-04-12-git-security-vulnerability-announced/